### PR TITLE
docs: expand version input documentation with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,52 @@ Following inputs can be used
 | Name           | Type   | Default                     | Description                                                      |
 |----------------|--------|-----------------------------|------------------------------------------------------------------|
 | `distribution` | String | `goreleaser`                | GoReleaser distribution, either `goreleaser` or `goreleaser-pro` |
-| `version`**¹** | String | `latest`                    | GoReleaser version                                               |
+| `version`      | String | `latest`                    | GoReleaser version (see below)                                   |
 | `args`         | String |                             | Arguments to pass to GoReleaser                                  |
 | `workdir`      | String | `$(Build.SourcesDirectory)` | Working directory (below repository root)                        |
 | `installOnly`  | Bool   | `false`                     | Just install GoReleaser                                          |
 
-> **¹** Can be a fixed version like `v0.132.0` or a max satisfying semver one like `~> 0.132`. In this case this will return `v0.132.1`.
-> For the `pro` version, add `-pro` to the string
+### Version input
+
+The `version` input accepts:
+
+- `latest` (default) — grabs the most recent release
+- An exact version like `v2.6.1`
+- A semver range like `~> 2.6`, which resolves to the highest matching release (e.g. the latest `2.6.x` patch)
+
+For GoReleaser Pro, append `-pro` to the version (e.g. `v2.6.1-pro`).
+
+#### Examples
+
+```yaml
+# Latest version
+- task: goreleaser@0
+  inputs:
+    version: 'latest'
+    distribution: 'goreleaser'
+    args: 'release --clean'
+
+# Exact version
+- task: goreleaser@0
+  inputs:
+    version: 'v2.6.1'
+    distribution: 'goreleaser'
+    args: 'release --clean'
+
+# Semver range — gets latest 2.6.x
+- task: goreleaser@0
+  inputs:
+    version: '~> 2.6'
+    distribution: 'goreleaser'
+    args: 'release --clean'
+
+# GoReleaser Pro
+- task: goreleaser@0
+  inputs:
+    version: 'v2.6.1-pro'
+    distribution: 'goreleaser-pro'
+    args: 'release --clean'
+```
 
 ### Environment variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/parser": "8.38.0",
         "eslint": "9.30.1",
         "prettier": "3.6.2",
-        "tfx-cli": "0.21.1",
+        "tfx-cli": "0.22.1",
         "ts-mocha": "11.1.0",
         "typescript": "5.8.3"
       }
@@ -870,25 +870,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/arch": {
-      "version": "2.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/archiver": {
       "version": "2.0.3",
       "dev": true,
@@ -1202,84 +1183,22 @@
       }
     },
     "node_modules/clipboardy": {
-      "version": "1.2.3",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
+      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "arch": "^2.1.0",
-        "execa": "^0.8.0"
+        "execa": "^8.0.1",
+        "is-wsl": "^3.1.0",
+        "is64bit": "^2.0.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/clipboardy/node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/clipboardy/node_modules/execa": {
-      "version": "0.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/clipboardy/node_modules/get-stream": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/clipboardy/node_modules/is-stream": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/clipboardy/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/clipboardy/node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/clipboardy/node_modules/yallist": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -1923,6 +1842,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/eyes": {
       "version": "0.1.8",
       "dev": true,
@@ -2080,20 +2023,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "dev": true,
@@ -2170,6 +2099,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -2344,6 +2286,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "dev": true,
@@ -2512,6 +2464,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -2540,6 +2508,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-negative-zero": {
@@ -2618,6 +2605,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "dev": true,
@@ -2669,6 +2669,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is64bit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
+      "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "system-architecture": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -3054,6 +3086,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3074,6 +3113,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -3311,6 +3363,22 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -3380,6 +3448,22 @@
         "node": ">=0.4.8"
       }
     },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "dev": true,
@@ -3402,22 +3486,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -3508,11 +3576,16 @@
       }
     },
     "node_modules/path-key": {
-      "version": "2.0.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-parse": {
@@ -3607,11 +3680,6 @@
       "engines": {
         "node": ">= 6.0.0"
       }
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3949,25 +4017,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/shebang-command": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/shelljs": {
       "version": "0.8.5",
       "dev": true,
@@ -4061,9 +4110,17 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.5",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -4195,12 +4252,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-eof": {
-      "version": "1.0.0",
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-indent": {
@@ -4236,6 +4298,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/system-architecture": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
+      "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "1.6.2",
       "dev": true,
@@ -4254,15 +4329,16 @@
       }
     },
     "node_modules/tfx-cli": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.21.1.tgz",
-      "integrity": "sha512-tQD3XqynSmlR1Teawp6ogUNSXLXsmRfSNSRXXcQ/FePGRp09avIGsZfiF8F03NwzzhMU2HSqbGThY2vc94OBEw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.22.1.tgz",
+      "integrity": "sha512-LhKzq0HJ7/kznsoCsoX+wqeYzHCfS0RuBMT4g6/pEZ+cPPZZIKC55Nh+0XwjaruVVoMuuK5BrNk2QHS6gDfk5Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "app-root-path": "1.0.0",
         "archiver": "2.0.3",
         "azure-devops-node-api": "^14.0.0",
-        "clipboardy": "~1.2.3",
+        "clipboardy": "^4.0.0",
         "colors": "~1.3.0",
         "glob": "7.1.2",
         "jju": "^1.4.0",
@@ -4276,7 +4352,7 @@
         "prompt": "^1.3.0",
         "read": "^1.0.6",
         "shelljs": "^0.8.5",
-        "tmp": "0.0.26",
+        "tmp": "^0.2.4",
         "tracer": "0.7.4",
         "util.promisify": "^1.0.0",
         "uuid": "^3.0.1",
@@ -4326,22 +4402,22 @@
         "node": ">=10"
       }
     },
-    "node_modules/tfx-cli/node_modules/tmp": {
-      "version": "0.0.26",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/tinytim": {
       "version": "0.1.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-buffer": {
@@ -4643,17 +4719,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/which-boxed-primitive": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/parser": "8.38.0",
     "eslint": "9.30.1",
     "prettier": "3.6.2",
-    "tfx-cli": "0.21.1",
+    "tfx-cli": "0.22.1",
     "ts-mocha": "11.1.0",
     "typescript": "5.8.3"
   }


### PR DESCRIPTION
## Summary

- Replaces the sparse footnote about the `version` input with a proper section and examples
- Covers all three formats: `latest`, exact version (`v2.6.1`), and semver range (`~> 2.6`)
- Includes a GoReleaser Pro example

Closes #1233