### PR TITLE
fix: skip marketplace validation wait in publish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-and-fix": "eslint . --ext .ts --fix",
     "create": "rm -rf dist ; npm run compile ; tfx extension create --manifest-globs vss-extension.json --output-path dist",
     "release": "npx release-it -- --ci",
-    "publish_ci": "tfx extension publish --manifest-globs vss-extension.json --auth-type pat --token $AZURE_DEVOPS_EXT_PAT --publisher $PUBLISHER_NAME --extension-id $EXTENSION_ID --vsix dist/$PUBLISHER_NAME.$EXTENSION_ID-$VERSION.vsix",
+    "publish_ci": "tfx extension publish --manifest-globs vss-extension.json --auth-type pat --token $AZURE_DEVOPS_EXT_PAT --publisher $PUBLISHER_NAME --extension-id $EXTENSION_ID --vsix dist/$PUBLISHER_NAME.$EXTENSION_ID-$VERSION.vsix --no-wait-validation",
     "unpublish_ci": "tfx extension unpublish --manifest-globs vss-extension.json --auth-type pat --token $AZURE_DEVOPS_EXT_PAT --publisher $PUBLISHER_NAME --extension-id $EXTENSION_ID",
     "share_dev": "tfx extension share --token $AZURE_DEVOPS_EXT_PAT --publisher $PUBLISHER_NAME --extension-id $EXTENSION_ID --share-with $SHARE_WITH_DEV_ORGA"
   },


### PR DESCRIPTION
## Summary
- Add `--no-wait-validation` to the `tfx extension publish` command in the `publish_ci` script
- The `tfx` CLI has been timing out waiting for Microsoft's marketplace validation to complete, causing CI to report failure even though the extension gets published successfully
- With this flag, `tfx` uploads the extension and returns immediately instead of polling the validation endpoint until it times out

## Test plan
- [ ] Merge and verify the next release's publish step doesn't time out